### PR TITLE
security: SSRF hardening and path traversal mitigation

### DIFF
--- a/mealie/pkgs/safehttp/transport.py
+++ b/mealie/pkgs/safehttp/transport.py
@@ -1,6 +1,7 @@
 import ipaddress
 import logging
 import socket
+from typing import Iterable
 
 import httpx
 
@@ -41,36 +42,60 @@ class AsyncSafeTransport(httpx.AsyncBaseTransport):
         # validate the request is not attempting to connect to a local IP
         # This is a security measure to prevent SSRF attacks
 
-        ip: ipaddress.IPv4Address | ipaddress.IPv6Address | None = None
+        def is_disallowed_ip(candidate: ipaddress._BaseAddress) -> bool:
+            """Return True if the IP should be blocked for SSRF protection."""
+            return (
+                candidate.is_private
+                or candidate.is_loopback
+                or candidate.is_link_local
+                or candidate.is_multicast
+                or candidate.is_reserved
+                or candidate.is_unspecified
+                or candidate in ipaddress.ip_network("100.64.0.0/10")
+            )
 
-        netloc = request.url.netloc.decode()
-        if ":" in netloc:  # Either an IP, or a hostname:port combo
-            netloc_parts = netloc.split(":")
-
-            netloc = netloc_parts[0]
-
+        def resolve_all(hostname: str) -> Iterable[ipaddress._BaseAddress]:
+            """Resolve all A/AAAA records for a hostname; if it's already an IP, yield it."""
             try:
-                ip = ipaddress.ip_address(netloc)
+                # If hostname is a literal IP
+                yield ipaddress.ip_address(hostname)
+                return
             except ValueError:
-                if self._log:
-                    self._log.debug(f"failed to parse ip for {netloc=} falling back to domain resolution")
                 pass
 
-        # Request is a domain or a hostname.
-        if not ip:
-            if self._log:
-                self._log.debug(f"resolving IP for domain: {netloc}")
+            try:
+                for family in (socket.AF_INET, socket.AF_INET6):
+                    try:
+                        infos = socket.getaddrinfo(hostname, None, family, socket.SOCK_STREAM)
+                    except socket.gaierror:
+                        continue
+                    for info in infos:
+                        addr = info[4][0]
+                        try:
+                            yield ipaddress.ip_address(addr)
+                        except ValueError:
+                            continue
+            except Exception:
+                # Fall back to single resolution
+                try:
+                    ip_str = socket.gethostbyname(hostname)
+                    yield ipaddress.ip_address(ip_str)
+                except Exception:
+                    return
 
-            ip_str = socket.gethostbyname(netloc)
-            ip = ipaddress.ip_address(ip_str)
+        netloc = request.url.netloc.decode()
+        host = netloc.split(":", 1)[0]
 
-            if self._log:
-                self._log.debug(f"resolved IP for domain: {netloc} -> {ip}")
-
-        if ip.is_private:
-            if self._log:
-                self._log.warning(f"invalid request on local resource: {request.url} -> {ip}")
-            raise InvalidDomainError(f"invalid request on local resource: {request.url} -> {ip}")
+        # Validate all resolved addresses
+        for resolved_ip in resolve_all(host):
+            if is_disallowed_ip(resolved_ip):
+                if self._log:
+                    self._log.warning(
+                        f"invalid request on disallowed IP for {request.url} -> {resolved_ip}"
+                    )
+                raise InvalidDomainError(
+                    f"invalid request on disallowed IP for {request.url} -> {resolved_ip}"
+                )
 
         return await self._wrapper.handle_async_request(request)
 

--- a/mealie/routes/media/media_user.py
+++ b/mealie/routes/media/media_user.py
@@ -1,6 +1,7 @@
 from fastapi import APIRouter, HTTPException, status
 from pydantic import UUID4
 from starlette.responses import FileResponse
+from pathlib import Path
 
 from mealie.schema.user import PrivateUser
 
@@ -9,11 +10,26 @@ router = APIRouter(prefix="/users")
 
 @router.get("/{user_id}/{file_name}", response_class=FileResponse)
 async def get_user_image(user_id: UUID4, file_name: str):
-    """Takes in a recipe slug, returns the static image. This route is proxied in the docker image
-    and should not hit the API in production"""
-    recipe_image = PrivateUser.get_directory(user_id) / file_name
+    """Serve a user's image file, preventing path traversal outside the user directory."""
+    user_dir = PrivateUser.get_directory(user_id)
 
-    if recipe_image.exists():
-        return FileResponse(recipe_image, media_type="image/webp")
+    # Disallow absolute paths and parent directory traversal
+    candidate = (user_dir / file_name).resolve()
+    try:
+        user_dir_resolved = user_dir.resolve()
+    except Exception:
+        user_dir_resolved = Path(user_dir)
+
+    if not str(candidate).startswith(str(user_dir_resolved) + str(Path("/") )):
+        # Fallback safe check for platforms without commonpath
+        try:
+            from os.path import commonpath
+            if commonpath([str(candidate), str(user_dir_resolved)]) != str(user_dir_resolved):
+                raise HTTPException(status.HTTP_400_BAD_REQUEST, "invalid file path")
+        except Exception:
+            raise HTTPException(status.HTTP_400_BAD_REQUEST, "invalid file path")
+
+    if candidate.exists() and candidate.is_file():
+        return FileResponse(candidate, media_type="image/webp")
     else:
         raise HTTPException(status.HTTP_404_NOT_FOUND)


### PR DESCRIPTION
This PR hardens SSRF protections and prevents path traversal in user image serving.\n\nChanges:\n- SSRF: resolve all A/AAAA; block private/loopback/link-local/multicast/reserved/unspecified and RFC6598 before request.\n- User images: resolve and enforce path within user directory, reject invalid paths.\n\nNotes:\n- No API surface changes.\n- Lints pass on edited files.\n\nPlease review.