### PR TITLE
security: tighten CSRF origin checks and docs updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,10 @@ Mealie is a self hosted recipe manager, meal planner and shopping list with a Re
 - Docker: Easy **Docker** deployment
 - Localisation: **Translations** for 35+ languages
 
+### Security configuration
+- BASE_URL: Set to your frontend origin (scheme+host+port). In development, use `http://localhost:3000` to match the Nuxt app; in production, set to your public site origin. This is used for CSRF Origin/Referer checks.
+- HOST_IP: Set to a comma-separated list of trusted proxy IPs or networks (e.g. `127.0.0.1,10.0.0.0/8`) for forwarded header trust. Avoid `*` in production.
+
 <!-- CONTRIBUTING -->
 ## Contributing
 

--- a/mealie/app.py
+++ b/mealie/app.py
@@ -11,11 +11,12 @@ from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
 
 import uvicorn
-from fastapi import FastAPI
+from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.middleware.gzip import GZipMiddleware
 from fastapi.routing import APIRoute
 from starlette.middleware.sessions import SessionMiddleware
+from starlette.middleware.base import BaseHTTPMiddleware
 
 from mealie.core.config import get_app_settings
 from mealie.core.root_logger import get_logger
@@ -163,6 +164,30 @@ for route in app.routes:
         route.tags = list(set(route.tags))
 
 
+class CSRFMiddleware(BaseHTTPMiddleware):
+    async def dispatch(self, request: Request, call_next):
+        # Only enforce on state-changing methods where cookie auth might be used
+        if request.method in {"POST", "PUT", "PATCH", "DELETE"}:
+            # If auth cookie is present, require Origin/Referer to match BASE_URL
+            if "mealie.access_token" in request.cookies:
+                origin = request.headers.get("origin") or ""
+                referer = request.headers.get("referer") or ""
+                allowed = settings.BASE_URL
+                if not (origin.startswith(allowed) or referer.startswith(allowed)):
+                    from fastapi import status as _status
+                    from fastapi.responses import JSONResponse
+
+                    return JSONResponse(
+                        status_code=_status.HTTP_403_FORBIDDEN,
+                        content={"detail": "CSRF check failed"},
+                    )
+
+        return await call_next(request)
+
+
+app.add_middleware(CSRFMiddleware)
+
+
 def main():
     uvicorn.run(
         "app:app",
@@ -175,7 +200,7 @@ def main():
         use_colors=True,
         log_config=None,
         workers=1,
-        forwarded_allow_ips="*",
+        forwarded_allow_ips=settings.HOST_IP,
     )
 
 

--- a/mealie/app.py
+++ b/mealie/app.py
@@ -166,21 +166,42 @@ for route in app.routes:
 
 class CSRFMiddleware(BaseHTTPMiddleware):
     async def dispatch(self, request: Request, call_next):
+        # Skip CSRF checks in development to ease local workflows
+        if not settings.PRODUCTION:
+            return await call_next(request)
+
         # Only enforce on state-changing methods where cookie auth might be used
         if request.method in {"POST", "PUT", "PATCH", "DELETE"}:
-            # If auth cookie is present, require Origin/Referer to match BASE_URL
+            # If auth cookie is present, require Origin/Referer to match BASE_URL exactly (scheme+host+port)
             if "mealie.access_token" in request.cookies:
                 origin = request.headers.get("origin") or ""
                 referer = request.headers.get("referer") or ""
-                allowed = settings.BASE_URL
-                if not (origin.startswith(allowed) or referer.startswith(allowed)):
+
+                try:
+                    from urllib.parse import urlparse
+                    allowed_parts = urlparse(settings.BASE_URL)
+                    allowed = (allowed_parts.scheme, allowed_parts.hostname, allowed_parts.port)
+
+                    def is_allowed(url: str) -> bool:
+                        if not url:
+                            return False
+                        parts = urlparse(url)
+                        host_port = parts.port
+                        # Infer default port if missing
+                        if host_port is None:
+                            host_port = 443 if parts.scheme == "https" else 80
+                        return (parts.scheme, parts.hostname, host_port) == (
+                            allowed[0], allowed[1], allowed[2] or (443 if allowed_parts.scheme == "https" else 80)
+                        )
+
+                    if not (is_allowed(origin) or is_allowed(referer)):
+                        from fastapi import status as _status
+                        from fastapi.responses import JSONResponse
+                        return JSONResponse(status_code=_status.HTTP_403_FORBIDDEN, content={"detail": "CSRF check failed"})
+                except Exception:
                     from fastapi import status as _status
                     from fastapi.responses import JSONResponse
-
-                    return JSONResponse(
-                        status_code=_status.HTTP_403_FORBIDDEN,
-                        content={"detail": "CSRF check failed"},
-                    )
+                    return JSONResponse(status_code=_status.HTTP_403_FORBIDDEN, content={"detail": "CSRF check failed"})
 
         return await call_next(request)
 

--- a/mealie/routes/auth/auth.py
+++ b/mealie/routes/auth/auth.py
@@ -95,6 +95,7 @@ def get_token(
         httponly=True,
         max_age=expires_in,
         secure=settings.PRODUCTION,
+        samesite="strict",
     )
 
     return MealieAuthToken.respond(access_token)
@@ -155,6 +156,7 @@ async def oauth_callback(request: Request, response: Response, session: Session 
         httponly=True,
         max_age=expires_in,
         secure=settings.PRODUCTION,
+        samesite="strict",
     )
 
     return MealieAuthToken.respond(access_token)


### PR DESCRIPTION
This PR finalizes the tight CSRF configuration and documents BASE_URL and HOST_IP.\n\nChanges:\n- CSRFMiddleware: exact origin match (scheme+host+port); disabled in dev.\n- Cookies: SameSite=Strict already applied.\n- Uvicorn forwarded headers: use settings.HOST_IP.\n- README: security configuration notes for BASE_URL and HOST_IP.\n\nNo API changes; lints pass.
